### PR TITLE
Fail the build when the packaged binding does not match the package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebuild": "rimraf ./nodejs/dist",
     "build": "tsc",
-    "postbuild": "mkdir ./nodejs/dist/lib/binding && cp ./nodejs/lib/binding/node_setapp_binding.node ./nodejs/dist/lib/binding/node_setapp_binding.node",
+    "postbuild": "mkdir ./nodejs/dist/lib/binding && cp ./nodejs/lib/binding/node_setapp_binding.node ./nodejs/dist/lib/binding/node_setapp_binding.node && node ./scripts/check-binding-version.js",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/scripts/check-binding-version.js
+++ b/scripts/check-binding-version.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Fail the build if the packaged N-API binding was compiled against a different
+ * Setapp library than this package version.
+ *
+ * `postbuild` copies `nodejs/lib/binding/node_setapp_binding.node` into
+ * `nodejs/dist/lib/binding/`, and `nodejs/dist` is what `main` loads. That
+ * source directory is gitignored, so on a machine where node-gyp has not run
+ * for the current version it holds a binding left over from an earlier one -
+ * and the copy succeeds silently.
+ *
+ * The binding statically links the Swift library, so the version it was built
+ * against is the version consumers actually run, whatever package.json says.
+ * Nothing downstream can detect or correct that.
+ *
+ * Every Mach-O the framework produces carries an embedded `__scv__<version>`
+ * stamp. This compares that stamp with the package version.
+ */
+const fs = require("fs");
+const path = require("path");
+
+const root = path.join(__dirname, "..");
+const pkg = require(path.join(root, "package.json"));
+const binding = path.join(
+  root, "nodejs", "dist", "lib", "binding", "node_setapp_binding.node",
+);
+
+if (!fs.existsSync(binding)) {
+  console.error(`[check-binding-version] no binding at ${path.relative(root, binding)}`);
+  console.error("  postbuild should have copied it from nodejs/lib/binding.");
+  process.exit(1);
+}
+
+// latin1 so bytes survive decoding; the stamp is plain ASCII inside a binary.
+const stamp = fs.readFileSync(binding, "latin1").match(/__scv__(\d+\.\d+\.\d+)/);
+
+if (!stamp) {
+  console.error(`[check-binding-version] no __scv__ version stamp found in the binding.`);
+  process.exit(1);
+}
+
+if (stamp[1] !== pkg.version) {
+  console.error(
+    `[check-binding-version] the binding is built against Setapp ${stamp[1]}, ` +
+    `but this package is ${pkg.version}.\n` +
+    `\n` +
+    `  ${path.relative(root, binding)}\n` +
+    `\n` +
+    `Publishing this would ship a library ${stamp[1]} runtime as ${pkg.version}: the\n` +
+    `binding statically links the Swift library, so its version is what consumers run,\n` +
+    `and any API added since ${stamp[1]} would be missing with no way to detect it.\n` +
+    `\n` +
+    `Rebuild the native binding for this version, then run the build again:\n` +
+    `  npx node-gyp rebuild && npm run build\n`,
+  );
+  process.exit(1);
+}
+
+console.log(`[check-binding-version] binding matches package (Setapp ${pkg.version})`);


### PR DESCRIPTION
Fixes #68.

## The problem

`postbuild` copies `nodejs/lib/binding/node_setapp_binding.node` into `nodejs/dist/lib/binding/`, and `nodejs/dist` is what `main` loads. That source directory is gitignored, so on a machine where node-gyp has not run for the current version it holds a binding left over from an earlier one — and the copy succeeds silently.

Because the binding statically links the Swift library, the version it was built against is the version consumers actually run, whatever `package.json` says. Nothing downstream can detect or correct it.

The published packages show the effect (versions and stamps taken straight from npm):

| package | `libSetapp.a` | published binding |
|---|---|---|
| 5.3.0 | 5.3.0 | 5.2.1 |
| 5.3.1 | 5.3.1 | 5.2.1 |
| 5.3.2 | 5.3.2 | 5.2.1 |
| 5.3.3 | 5.3.3 | 5.2.1 |

The full table in #68 goes back to 4.3.4; `5.1.0` appears to be the only release where the two matched.

## The change

One check appended to `postbuild`, comparing the copied binary's embedded `__scv__` stamp with the package version, failing the build on a mismatch.

```
"postbuild": "... && node ./scripts/check-binding-version.js"
```

`scripts/` is outside the tsconfig `include` (`"nodejs"`) and outside the published `files` list, so it is neither compiled nor shipped.

## Verified

Run against real binaries on macOS 26.5 / Node 24:

| input | result |
|---|---|
| the published 5.3.3 binding (built against 5.2.1) | **exit 1**, names both versions |
| a 5.3.3 binding built from this repo at the `5.3.3` tag | exit 0 |
| binding missing | exit 1 |
| file present but carrying no stamp | exit 1 |

The failure output:

```
[check-binding-version] the binding is built against Setapp 5.2.1, but this package is 5.3.3.

  nodejs/dist/lib/binding/node_setapp_binding.node

Publishing this would ship a library 5.2.1 runtime as 5.3.3: the
binding statically links the Swift library, so its version is what consumers run,
and any API added since 5.2.1 would be missing with no way to detect it.

Rebuild the native binding for this version, then run the build again:
  npx node-gyp rebuild && npm run build
```

## Notes

- This is intentionally a **guard, not an automatic rebuild**. Adding `node-gyp rebuild` to `build` would change how release artifacts are produced, which is your call to make; a check that refuses the wrong binary is safe either way. Happy to switch it to a warning if you would rather not fail the build.
- It does not fix the already-published packages — those need a republish with a rebuilt binding.
- It also does not address the second half of #68: a binding built from this repo carries the correct library but does not complete the provisioning handshake for us, while the published one does. We could not work out why, and would value a pointer.
